### PR TITLE
Bugfix: Expansion of escape sequences had wrong priority

### DIFF
--- a/env.go
+++ b/env.go
@@ -205,6 +205,8 @@ func tokenizeSliceString(s string) ([]string, error) {
 
 func unescapeSliceField(f string) string {
 	runes := []rune(f)
+
+	// Trim trailing spaces (find end of the string).
 	end := len(runes) - 1
 	for ; end >= 0; end-- {
 		if unicode.IsSpace(runes[end]) {
@@ -214,9 +216,13 @@ func unescapeSliceField(f string) string {
 		}
 		break
 	}
+
+	// Trim leading spaces (find start of the string).
 	start := 0
 	for ; start < len(runes) && unicode.IsSpace(runes[start]); start++ {
 	}
+
+	// Extract and unescape the string.
 	var sb strings.Builder
 	for i := start; i <= end; i++ {
 		if runes[i] == '\\' {

--- a/env.go
+++ b/env.go
@@ -204,15 +204,14 @@ func (l *loader) parseAndSetSlice(s string, rv reflect.Value) error {
 		// Get rid of leading and trailing spaces of each field.
 		f = strings.TrimSpace(f)
 
-		// Get rid of stand-alone double-quotes and transform the
-		// escaped double-quotes into the real ones.
-		f = strings.ReplaceAll(f, `\"`, "\x00")
-		f = strings.ReplaceAll(f, `"`, "")
-		f = strings.ReplaceAll(f, "\x00", `"`)
-
-		// Get rid of stand-alone back-slashes and transform the
-		// escaped back-slashes into the real ones.
+		// 1) Get rid of stand-alone double-quotes and transform the
+		//    escaped double-quotes into the real ones.
+		// 2) Get rid of stand-alone back-slashes and transform the
+		//    escaped back-slashes into the real ones.
 		f = strings.ReplaceAll(f, `\\`, "\x00")
+		f = strings.ReplaceAll(f, `\"`, " \x00\x00 ")
+		f = strings.ReplaceAll(f, `"`, "")
+		f = strings.ReplaceAll(f, " \x00\x00 ", `"`)
 		f = strings.ReplaceAll(f, `\`, "")
 		f = strings.ReplaceAll(f, "\x00", `\`)
 

--- a/env_test.go
+++ b/env_test.go
@@ -181,8 +181,10 @@ func TestSlice(t *testing.T) {
 			`fo"o,o`,
 			`aa`,
 		},
-		`\?`: {`?`},
+		`\?`:      {`?`},
 		`"foo\\"`: {`foo\`},
+		`  "" ,`:  {``},
+		`  " " ,`: {` `},
 	}
 	type cfg struct {
 		Slice []string `env:"SLICE"`

--- a/env_test.go
+++ b/env_test.go
@@ -182,6 +182,7 @@ func TestSlice(t *testing.T) {
 			`aa`,
 		},
 		`\?`: {`?`},
+		`"foo\\"`: {`foo\`},
 	}
 	type cfg struct {
 		Slice []string `env:"SLICE"`

--- a/env_test.go
+++ b/env_test.go
@@ -181,10 +181,11 @@ func TestSlice(t *testing.T) {
 			`fo"o,o`,
 			`aa`,
 		},
-		`\?`:      {`?`},
-		`"foo\\"`: {`foo\`},
-		`  "" ,`:  {``},
-		`  " " ,`: {` `},
+		`\?`:           {`?`},
+		`"foo\\"`:      {`foo\`},
+		`foo \\\\ bar`: {`foo \\ bar`},
+		`  "" ,`:       {``},
+		`  " " ,`:      {` `},
 	}
 	type cfg struct {
 		Slice []string `env:"SLICE"`


### PR DESCRIPTION
Double bask-slashes should expand first, then the quotes. See the added example in tests.