### PR TITLE
Allow also struct parsing for regexp and templates

### DIFF
--- a/env.go
+++ b/env.go
@@ -342,11 +342,10 @@ func defaultParsers() map[reflect.Type]parseFunc {
 		reflect.TypeOf(int64(0)):         parseInt64,
 		reflect.TypeOf(uint64(0)):        parseUint64,
 		reflect.TypeOf(string("")):       parseString,
-		reflect.TypeOf(&regexp.Regexp{}): parseRegex,
+		reflect.TypeOf(regexp.Regexp{}):  parseRegex,
 		reflect.TypeOf(time.Duration(0)): parseDuration,
 		reflect.TypeOf(url.URL{}):        parseURL,
-		reflect.TypeOf(&url.URL{}):       parseURLPtr,
-		reflect.TypeOf(&tt.Template{}):   parseTextTemplate,
+		reflect.TypeOf(tt.Template{}):    parseTextTemplate,
 	}
 }
 
@@ -426,7 +425,11 @@ func parseString(s string) (interface{}, error) {
 }
 
 func parseRegex(s string) (interface{}, error) {
-	return regexp.Compile(s)
+	r, err := regexp.Compile(s)
+	if err != nil {
+		return nil, err
+	}
+	return *r, nil
 }
 
 func parseDuration(s string) (interface{}, error) {
@@ -442,10 +445,10 @@ func parseURL(s string) (interface{}, error) {
 	return *url, nil
 }
 
-func parseURLPtr(s string) (interface{}, error) {
-	return url.Parse(s)
-}
-
 func parseTextTemplate(s string) (interface{}, error) {
-	return tt.New("from_env").Parse(s)
+	t, err := tt.New("from_env").Parse(s)
+	if err != nil {
+		return nil, err
+	}
+	return *t, nil
 }

--- a/env_test.go
+++ b/env_test.go
@@ -5,9 +5,11 @@ import (
 	"math"
 	"net/url"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
+	tt "text/template"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -33,6 +35,8 @@ type config struct {
 	StringSlice []string      `env:"STRING_SLICE"`
 	URLValue    url.URL       `env:"URL_VALUE"`
 	URLPtr      *url.URL      `env:"URL_PTR"`
+	Regexp      regexp.Regexp `env:"REGEXP"`
+	Template    tt.Template   `env:"TEMPLATE"`
 	badConfig   int           //nolint:structcheck,unused
 }
 
@@ -67,6 +71,8 @@ var (
 		"STRING_SLICE": `"comma separated",values`,
 		"URL_VALUE":    "https://example.org",
 		"URL_PTR":      "https://example.org",
+		"REGEXP":       "^[a-c]bbf*d+c*$",
+		"TEMPLATE":     "{{23 -}} < {{- 45}}",
 	}
 	invalidVars = environment{
 		"BOOL":         "flase",
@@ -88,6 +94,14 @@ var (
 		StringSlice: []string{"comma separated", "values"},
 		URLValue:    url.URL{Scheme: "https", Host: "example.org"},
 		URLPtr:      &url.URL{Scheme: "https", Host: "example.org"},
+		Regexp:      *regexp.MustCompile("^[a-c]bbf*d+c*$"),
+		Template: func() tt.Template {
+			t, err := tt.New("from_env").Parse("{{23 -}} < {{- 45}}")
+			if err != nil {
+				panic(err.Error())
+			}
+			return *t
+		}(),
 	}
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=


### PR DESCRIPTION
The `env` package will correctly follow pointers, so all our default parsers should be used only for values, not for pointers. Otherwise, `env` package wouldn't be able to parse the struct itself. 