### PR TITLE
Use UnmarshalText when available.

### DIFF
--- a/env_test.go
+++ b/env_test.go
@@ -1,6 +1,7 @@
 package env
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"net/url"
@@ -567,6 +568,27 @@ func TestMapDurations(t *testing.T) {
 			os.Unsetenv("MAP_" + k.String())
 		}
 	}
+}
+
+type customMap map[string]string
+
+func (m *customMap) UnmarshalText(text []byte) error {
+	return json.Unmarshal(text, (*map[string]string)(m))
+}
+
+func TestMapWithCustomUnmarshaler(t *testing.T) {
+	a := assert.New(t)
+
+	type cfg struct {
+		Map customMap `env:"MAP"`
+	}
+	os.Setenv("MAP", `{"key": "value"}`)
+	defer os.Unsetenv("MAP")
+
+	var c cfg
+	err := Load(&c, "")
+	a.NoError(err)
+	a.Equal(customMap{"key": "value"}, c.Map)
 }
 
 func TestFileMode(t *testing.T) {


### PR DESCRIPTION
This changes the behavior for maps that define their own `UnmarshalText` method.  Currently `UnmarshalText` has lower priority which forces wrapping of that map in a struct and defining `UnmarshalText` on that struct; after this change `UnmarshalText` takes precedence if available.

`TestMapWithCustomUnmarshaler` contains a common use case: reading the map from JSON.

Thanks for sharing the library!